### PR TITLE
Support installing ffmpeg on architectures other than x86_64

### DIFF
--- a/install.ffmpeg.sh
+++ b/install.ffmpeg.sh
@@ -193,7 +193,7 @@ function install_ndi {
         tail -n+$ARCHIVE "$ndi_file" | tar xvz
     fi
 
-    libname=$(find "$ndi_dir/lib/x86_64-linux-gnu/" -type f)
+    libname=$(find "$ndi_dir/lib/$(uname -m)-linux-gnu/" -type f)
     libbase=$(basename "$libname")
 
     cp "$ndi_dir/include/"* /usr/include


### PR DESCRIPTION
libndi is available for i686 as well; choose the correct version of the library.

(This doesn't handle arm, though, because they ship 3 different arm libraries and it would require more work to figure out which one is appropriate for a given system.)